### PR TITLE
Capitalize help strings

### DIFF
--- a/_nix
+++ b/_nix
@@ -58,7 +58,7 @@ for option_description in $common_options_descriptions; do
 done
 
 # The --store option is undocumented for some reason
-common_options+=("--store[Select a nix store]:Store:->STORE-URI")
+common_options+=("--store[select a nix store]:Store:->STORE-URI")
 
 local -a main_commands
 # Extract the commands with descriptions

--- a/_nix-build
+++ b/_nix-build
@@ -7,11 +7,11 @@ local -a _nix_build_opts=(
     $__nix_expr_opts
     $__nix_common_store_opts
     '*'{--attr,-A}'[build a package from file (default: ./default.nix)]:package:_nix_complete_attr_paths'
-    --check'[Rebuild derivation]'
-    '--drv-link[Add a symlink to the store derivation]:Symlink Name:( )'
-    '--add-drv-link[Shorthand for --drv-link ./derivation]'
-    '--no-out-link[Do not create a symlink to the output path]'
-    {--out-link,-o}'[Name of the output symlink]:Output Symlink Name:( )'
+    --check'[rebuild derivation]'
+    '--drv-link[add a symlink to the store derivation]:Symlink Name:( )'
+    '--add-drv-link[shorthand for --drv-link ./derivation]'
+    '--no-out-link[do not create a symlink to the output path]'
+    {--out-link,-o}'[name of the output symlink]:Output Symlink Name:( )'
 )
 
 # TODO: Undocumented args to possibly add

--- a/_nix-channel
+++ b/_nix-channel
@@ -7,11 +7,11 @@ typeset -A opt_args
 _nix-common-options
 
 _arguments \
-  '(- *)--add[Subscribe to a channel]:Channel URL:_urls::Channel Name:( )'\
-  '(- *)--remove[Unsubscribe from a channel]:Channel Name:->nix_channels'\
-  '(- *)--list[List subscribed channels]'\
-  '(- *)--update[Update and activate channels]:Channel Name:->nix_channels'\
-  '(- *)--rollback[Revert the previous nix-channel --update]'
+  '(- *)--add[subscribe to a channel]:Channel URL:_urls::Channel Name:( )'\
+  '(- *)--remove[unsubscribe from a channel]:Channel Name:->nix_channels'\
+  '(- *)--list[list subscribed channels]'\
+  '(- *)--update[update and activate channels]:Channel Name:->nix_channels'\
+  '(- *)--rollback[revert the previous nix-channel --update]'
 
 case $state in
     nix-channels)

--- a/_nix-collect-garbage
+++ b/_nix-collect-garbage
@@ -4,6 +4,6 @@
 _nix-common-options
 
 _arguments \
-  '(--delete-old -d)'{--delete-old,-d}'[Delete all old generations of all profiles]'\
-  '--delete-older-than[Delete generations older than the given time]:Time such as 30d:( )'\
+  '(--delete-old -d)'{--delete-old,-d}'[delete all old generations of all profiles]'\
+  '--delete-older-than[delete generations older than the given time]:Time such as 30d:( )'\
   $__nix_dry_run \

--- a/_nix-common-options
+++ b/_nix-common-options
@@ -528,19 +528,19 @@ _nix_run_command_names () {
 
 # Used in: nix-build, nix-env, nix-instantiate, nix-shell, nixops
 __nix_boilerplate_opts=(
-    '(- *)--help[Print help message and exit]'
-    '(- *)--version[Print version number and exit]'
+    '(- *)--help[print help message and exit]'
+    '(- *)--version[print version number and exit]'
 )
 
 # Used in: nix-collect-garbage, nix-env, nix-store, nixops
-__nix_dry_run='--dry-run[Show what would be done without doing it]'
+__nix_dry_run='--dry-run[show what would be done without doing it]'
 
 # Used in: nix-collect-garbage, nix-store
 __nix_gc_common=(
-    '(- --print* --delete)--print-roots[Print roots used by garbage collector]'
-    '(- --print* --delete)--print-live[Print store paths reachable from roots]'
-    '(- --print* --delete)--print-dead[Print store paths not reachable from roots]'
-    '(- --print* --delete)--delete[Garbage collect all dead paths from the store]'
+    '(- --print* --delete)--print-roots[print roots used by garbage collector]'
+    '(- --print* --delete)--print-live[print store paths reachable from roots]'
+    '(- --print* --delete)--print-dead[print store paths not reachable from roots]'
+    '(- --print* --delete)--delete[garbage collect all dead paths from the store]'
 )
 
 # Used in: nixos-install, nix_common_opts
@@ -548,7 +548,7 @@ __nix_search_path_args=(
     '*-I[add a path to the list of locations used to look up <...> file names]:include path:_nix_complete_includes'
 )
 
-__nix_repair='--repair[Fix corrupted or missing store paths by redownloading or rebuilding]';
+__nix_repair='--repair[fix corrupted or missing store paths by redownloading or rebuilding]';
 
 __nix_expr_opts=(
     '(--expr -E)'{--expr,-E}'[interpret command line args as Nix expressions]'
@@ -558,14 +558,14 @@ __nix_expr_opts=(
 __nix_common_nixos_rebuild=(
     $__nix_search_path_args
     $__nix_repair
-    '(--verbose -v)*'{--verbose,-v}'[Increase verbosity of diagnostic messages]'
+    '(--verbose -v)*'{--verbose,-v}'[increase verbosity of diagnostic messages]'
     '(--no-build-output -Q)'{--no-build-output,-Q}'[silence output to stdout and stderr]'
     '(--max-jobs -j)'{--max-jobs,-j}'[max number of build jobs in parallel]:jobs:'
     '--cores[threads per job (e.g. -j argument to make)]:cores:'
     '(--keep-going -k)'{--keep-going,-k}"[keep going until all builds are finished]"
     '(--keep-failed -K)'{--keep-failed,-K}'[keep failed builds (usually in /tmp)]'
-    '--fallback[If binary download fails, fall back on building from source]'
-    '--show-trace[Print stack trace of evaluation errors]'
+    '--fallback[if binary download fails, fall back on building from source]'
+    '--show-trace[print stack trace of evaluation errors]'
     '*--option[set Nix configuration option]:options:_nix_options:value:_nix_options_value'
 )
 

--- a/_nix-copy-closure
+++ b/_nix-copy-closure
@@ -4,11 +4,11 @@
 _nix-common-options
 
 _arguments \
-  '(--from)--to[Copy the closure to the remote machine (default)]'\
-  '(--to)--from[Copy the closure from the remote machine]'\
-  '--sign[Cryptographically sign to allow sharing between untrusted users on trusted machines]'\
-  '--gzip[Enable compression of the SSH connection]'\
-  '--include-outputs[Also copy outputs of store derivations included in the closure]'\
-  '(--use-substitutes -s)'{--use-substitutes,-s}'[Download files from the binary cache if possible]'\
+  '(--from)--to[copy the closure to the remote machine (default)]'\
+  '(--to)--from[copy the closure from the remote machine]'\
+  '--sign[cryptographically sign to allow sharing between untrusted users on trusted machines]'\
+  '--gzip[enable compression of the SSH connection]'\
+  '--include-outputs[also copy outputs of store derivations included in the closure]'\
+  '(--use-substitutes -s)'{--use-substitutes,-s}'[download files from the binary cache if possible]'\
   '1:user@machine:_user_at_host'\
   '2:paths:_files'

--- a/_nix-env
+++ b/_nix-env
@@ -11,31 +11,31 @@ _nix-common-options
 
 local -a _1st_arguments
 _1st_arguments=(
-    {--install,-i}"[Install package]"
-    {--upgrade,-u}"[Upgrade package]"
-    {--uninstall,-e}"[Uninstall package]"
-    --set-flag'[Modify meta attribute of installed package]:Name:->flag_name:Value:->flag_value:*:Packages: _nix_installed_packages'
-    {--query,-q}"[List information about derivations]"
-    {--switch-profile,-S}"[Set the current profile path]"
-    "--list-generations[Print a list of all generations in the active profile]"
-    "--delete-generations[Delete specified generations]"
-    {--switch-generation,-G}"[Activate specified generation]"
-    "--rollback[Switch to the previous generation of active profile]"
+    {--install,-i}"[install package]"
+    {--upgrade,-u}"[upgrade package]"
+    {--uninstall,-e}"[uninstall package]"
+    --set-flag'[modify meta attribute of installed package]:Name:->flag_name:Value:->flag_value:*:Packages: _nix_installed_packages'
+    {--query,-q}"[list information about derivations]"
+    {--switch-profile,-S}"[set the current profile path]"
+    "--list-generations[print a list of all generations in the active profile]"
+    "--delete-generations[delete specified generations]"
+    {--switch-generation,-G}"[activate specified generation]"
+    "--rollback[switch to the previous generation of active profile]"
 )
 
 local -a _nix_env_common_opts=(
   $__nix_common_opts
-  '(--profile -p)'{--profile,-p}'[Specify the profile to use]:Path:_nix_profiles'
+  '(--profile -p)'{--profile,-p}'[specify the profile to use]:Path:_nix_profiles'
   $__nix_dry_run
-  '--system-filter[Only show derivations matching the specified platform]:system:_nix_systems'
+  '--system-filter[only show derivations matching the specified platform]:system:_nix_systems'
 )
 
 local -a _nix_env_b=(
-    '(--prebuilt-only -b)'{--prebuilt-only,-b}'[Fail if there is no pre-built binary available]'
+    '(--prebuilt-only -b)'{--prebuilt-only,-b}'[fail if there is no pre-built binary available]'
 )
 
 local _nix_env_from_profile
-_nix_env_from_profile='--from-profile[Fetch store paths from another profile]:Profile:_nix_profiles'
+_nix_env_from_profile='--from-profile[fetch store paths from another profile]:Profile:_nix_profiles'
 
 # Workaround:
 # opt_args doesn't record plain options, so we can't use that
@@ -56,11 +56,11 @@ case "$opt" in
     --install|-[^-]#i[^-]#)
         command_options=(
             $_nix_env_common_opts
-            '(--attr -A)'{--attr,-A}'[Specify packages by attribute path instead of name]'
+            '(--attr -A)'{--attr,-A}'[specify packages by attribute path instead of name]'
             $_nix_env_b
             $_nix_env_from_profile
-            '(--preserve-installed -P)'{--preserve-installed,-P}'[Do not remove derivations with the same name]'
-            '(--remove-all -r)'{--remove-all,-r}'[Remove all previously installed packages prior to installing]'
+            '(--preserve-installed -P)'{--preserve-installed,-P}'[do not remove derivations with the same name]'
+            '(--remove-all -r)'{--remove-all,-r}'[remove all previously installed packages prior to installing]'
             '*:Package:{if $expect_attr_paths; then
                            _nix_complete_attr_paths;
                         else
@@ -73,10 +73,10 @@ case "$opt" in
             $_nix_env_common_opts
             $_nix_env_b
             $_nix_env_from_profile
-            '(-lt -leq -eq --always)--lt[Upgrade derivations with newer versions (default)]'
-            '(-lt -leq -eq --always)--leq[Upgrade derivations with the same or newer version]'
-            '(-lt -leq -eq --always)--eq[Upgrade derivations with equivalent versions]'
-            '(-lt -leq -eq --always)--always[Upgrade even if version number decreases]'
+            '(-lt -leq -eq --always)--lt[upgrade derivations with newer versions (default)]'
+            '(-lt -leq -eq --always)--leq[upgrade derivations with the same or newer version]'
+            '(-lt -leq -eq --always)--eq[upgrade derivations with equivalent versions]'
+            '(-lt -leq -eq --always)--always[upgrade even if version number decreases]'
             '*:Packages: _nix_installed_packages')
         break
         ;;
@@ -104,7 +104,7 @@ case "$opt" in
             '--description[print description]'
             '--xml[print output as xml]'
             '--json[print output as json]'
-            '--meta[Print all meta attributes: only available with --xml]')
+            '--meta[print all meta attributes: only available with --xml]')
         break
         ;;
     --switch-profile|-[^-]#S[^-]#)
@@ -133,7 +133,7 @@ done
 # Let _arguments handle the rest, with _1st_arguments being mutually exclusive
 # under the main_options group
 _arguments -s $command_options \
-           '*'{--file,-f}'[Specify Nix expression used to obtain derivations]:Path to file:_nix_path'\
+           '*'{--file,-f}'[specify Nix expression used to obtain derivations]:Path to file:_nix_path'\
            '-f.[evaluate ./default.nix rather than the default]' \
            $__nix_boilerplate_opts \
            - '(main_options)' \

--- a/_nix-hash
+++ b/_nix-hash
@@ -7,10 +7,10 @@ local -a ig
 ig=( '--to-base16' '--to-base32' )
 
 _arguments \
-  '(- *)--to-base16[Convert a base 32 hash to hexadecimal]:Hash:( )' \
-  '(- *)--to-base32[Convert a hexadecimal hash to base 32]:Hash:( )' \
-  "($ig)--flat[Print hash of regular files rather than their NAR dump]" \
-  "($ig)--base32[Print hash in base 32 rather than hexadecimal]" \
-  "($ig)--truncate[Truncate hashes to 160 bits]" \
-  "($ig)--type[Hash algorithm to use]:hashAlgo:(md5 sha1 sha256 sha512)" \
+  '(- *)--to-base16[convert a base 32 hash to hexadecimal]:Hash:( )' \
+  '(- *)--to-base32[convert a hexadecimal hash to base 32]:Hash:( )' \
+  "($ig)--flat[print hash of regular files rather than their NAR dump]" \
+  "($ig)--base32[print hash in base 32 rather than hexadecimal]" \
+  "($ig)--truncate[truncate hashes to 160 bits]" \
+  "($ig)--type[hash algorithm to use]:hashAlgo:(md5 sha1 sha256 sha512)" \
   "($ig)*:Store Paths:_files" && return 0

--- a/_nix-install-package
+++ b/_nix-install-package
@@ -4,8 +4,8 @@
 _nix-common-options
 
 _arguments \
-  '--non-interactive[Do not open a terminal window and do not ask for confirmation]' \
-  '(--profile -p)'{--profile,-p}'[Profile to install the package into]:Profile:_nix_profiles' \
-  '--set[Install the package as the profile so that the profile contains nothing else]' \
+  '--non-interactive[do not open a terminal window and do not ask for confirmation]' \
+  '(--profile -p)'{--profile,-p}'[profile to install the package into]:Profile:_nix_profiles' \
+  '--set[install the package as the profile so that the profile contains nothing else]' \
   '(1)--url[URL to download the package file from]:URL:_urls' \
   '(--url)1:Package File:_files -g \*.nixpkg'

--- a/_nix-instantiate
+++ b/_nix-instantiate
@@ -12,12 +12,12 @@ _arguments \
   $__nix_common_store_opts \
   $__nix_expr_opts \
   '*'{--attr,-A}'[build a .drv from file (default: ./default.nix)]:package:_nix_complete_attr_paths' \
-  '--xml[Print output from --eval as XML]'\
-  '--json[Print output from --eval as JSON]'\
-  '--parse[Just parse the input files and print their abstract syntax trees]'\
-  '--eval[Just parse and evaluate the input files, and print the resulting values]'\
-  '--strict[Cause --eval to recursively evaluate list elements and attributes]'\
-  '--read-write-mode[Perform evaluation in read/write mode]'\
+  '--xml[print output from --eval as XML]'\
+  '--json[print output from --eval as JSON]'\
+  '--parse[just parse the input files and print their abstract syntax trees]'\
+  '--eval[just parse and evaluate the input files, and print the resulting values]'\
+  '--strict[cause --eval to recursively evaluate list elements and attributes]'\
+  '--read-write-mode[perform evaluation in read/write mode]'\
   '*:File to instantiate (default\: ./default.nix):_nix_path' \
   - find-file \
-  "--find-file[Look up the given files on Nix's search path]:*:Lookup file using <...> logic:"\
+  "--find-file[look up the given files on Nix's search path]:*:Lookup file using <...> logic:"\

--- a/_nix-prefetch-url
+++ b/_nix-prefetch-url
@@ -5,10 +5,10 @@ _nix-common-options
 
 _arguments \
   $__nix_search_path_args \
-  '--unpack[Unpack tarball/zip first]'\
-  '--print-path[Print the resulting store path]'\
-  '--type[Use the specified hash algorithm]:Hash Algorithm:(md5 sha1 sha256 sha512)'\
-  '--name[Override the resulting nix store filename]:nix store filename:'\
-  '*'{--attr,-A}'[Fetch the src of derivation (eg. mpv.src)]:src (eg. mpv.src): _nix_complete_attr_paths'\
+  '--unpack[unpack tarball/zip first]'\
+  '--print-path[print the resulting store path]'\
+  '--type[use the specified hash algorithm]:Hash Algorithm:(md5 sha1 sha256 sha512)'\
+  '--name[override the resulting nix store filename]:nix store filename:'\
+  '*'{--attr,-A}'[fetch the src of derivation (eg. mpv.src)]:src (eg. mpv.src): _nix_complete_attr_paths'\
   '1:URL or a local nix file:_nix_path'\
   '2::Hash:( )'

--- a/_nix-push
+++ b/_nix-push
@@ -4,12 +4,12 @@
 _nix-common-options
 
 _arguments \
-  '--dest[Set the destination directory]:Destination directory:_path_files -/'\
-  '(--none)--bzip2[Compress NARs using bzip2 instead of xz -9]'\
-  '(--bzip2)--none[Do not compress NARs]'\
-  '--force[Overwrite .narinfo files if they already exist]'\
-  '--link[Hard link files into the destination directory rather than copying]'\
-  '(--manifest-path)--manifest[Force the generation of a manifest suitable for use by nix-pull]'\
-  '(--manifest)--manifest-path[Like --manifest, but specify the manifest filename]:Manifest filename:_files'\
-  '--url-prefix[Specify the prefix URL used in the Manifest]:Prefix URL:_urls'\
+  '--dest[set the destination directory]:Destination directory:_path_files -/'\
+  '(--none)--bzip2[compress NARs using bzip2 instead of xz -9]'\
+  '(--bzip2)--none[do not compress NARs]'\
+  '--force[overwrite .narinfo files if they already exist]'\
+  '--link[hard link files into the destination directory rather than copying]'\
+  '(--manifest-path)--manifest[force the generation of a manifest suitable for use by nix-pull]'\
+  '(--manifest)--manifest-path[like --manifest, but specify the manifest filename]:Manifest filename:_files'\
+  '--url-prefix[specify the prefix URL used in the Manifest]:Prefix URL:_urls'\
   '*:Derivation Paths:_files'

--- a/_nix-shell
+++ b/_nix-shell
@@ -4,10 +4,10 @@
 _nix-common-options
 
 local -a _nix_shell_opts=(
-  '--command[Run a command instead of starting an interactive shell]:Command:_command_names'
-  '--exclude[Do not build any dependencies which match this regex]:Regex:( )'
-  '--pure[Clear the environment before starting the interactive shell]'
-  '--run[Run a command in a non-interactive shell instead of starting an interactive shell]:Command:_command_names'
+  '--command[run a command instead of starting an interactive shell]:Command:_command_names'
+  '--exclude[do not build any dependencies which match this regex]:Regex:( )'
+  '--pure[clear the environment before starting the interactive shell]'
+  '--run[run a command in a non-interactive shell instead of starting an interactive shell]:Command:_command_names'
   '*'{--attr,-A}"[setup a build shell for package]:package:_nix_complete_attr_paths"
 )
 

--- a/_nix-store
+++ b/_nix-store
@@ -11,26 +11,26 @@ _nix-common-options
 
 local -a cmd_arguments=(
   $__nix_boilerplate_opts
-  {--realise,-r}'[Build the specified store paths]'
+  {--realise,-r}'[build the specified store paths]'
   '--serve[provide access to the nix store over stdin/stdout]'
-  '--gc[Perform garbage collection on the Nix store]'
-  '--delete[Delete store paths from the Nix store if it is safe to do so]'
-  {--query,-q}'[Display information about store paths]'
-  '--add[Add paths to the Nix store]'
-  '--verify[Verify the consistency of the Nix database and store]'
-  '--verify-path[Compare the contents of each store path to the hashes stored in the database]'
-  '--repair-path[Attempt to repair the specified paths by redownloading them]'
-  '--dump[Produce a NAR file containing the contents of the given path]'
-  '--restore[Unpack a NAR archive, read from stdin, to the given path]'
-  '--export[Serialize the specified store paths to stdout in a format which can be imported]'
-  '--import[Read searialized store paths from stdin and add them to the Nix store]'
-  '--optimise[Find identical files in the Nix store and hardlink them together to reduce disk usage]'
-  {--read-log,-l}'[Print the build log of the specified store paths]'
-  '--dump-db[Dump Nix database to stdout]'
-  '--load-db[Read a dump of the Nix database]'
-  '--print-env[Print the environment of a derivation as shell code]'
-  '--query-failed-paths[Print out store paths which failed to build]'
-  '--clear-failed-paths[Clear the "failed" state of the given store path]'
+  '--gc[perform garbage collection on the Nix store]'
+  '--delete[delete store paths from the Nix store if it is safe to do so]'
+  {--query,-q}'[display information about store paths]'
+  '--add[add paths to the Nix store]'
+  '--verify[verify the consistency of the Nix database and store]'
+  '--verify-path[compare the contents of each store path to the hashes stored in the database]'
+  '--repair-path[attempt to repair the specified paths by redownloading them]'
+  '--dump[produce a NAR file containing the contents of the given path]'
+  '--restore[unpack a NAR archive, read from stdin, to the given path]'
+  '--export[serialize the specified store paths to stdout in a format which can be imported]'
+  '--import[read searialized store paths from stdin and add them to the Nix store]'
+  '--optimise[find identical files in the Nix store and hardlink them together to reduce disk usage]'
+  {--read-log,-l}'[print the build log of the specified store paths]'
+  '--dump-db[dump Nix database to stdout]'
+  '--load-db[read a dump of the Nix database]'
+  '--print-env[print the environment of a derivation as shell code]'
+  '--query-failed-paths[print out store paths which failed to build]'
+  '--clear-failed-paths[clear the "failed" state of the given store path]'
   '--generate-binary-cache-key[generate an Ed25519 key pair to sign build outputs]:key-name::secret-key-file:_files:public-key-file:_files'
 )
 
@@ -72,14 +72,14 @@ case "$opt" in
     --delete)
         command_options=(
             $common_opts
-            '--ignore-liveness[Ignore reachability from roots]'
+            '--ignore-liveness[ignore reachability from roots]'
         )
         break
         ;;
     --query|-[^-]#q[^-]#)
         command_options+=(
-            '(--use-output -u)'{--use-output,-u}'[Apply the query to the output path of any store derivations]'
-            '(--force-realise -f)'{--force-realise,-f}'[Realise each argument to the query first]'
+            '(--use-output -u)'{--use-output,-u}'[apply the query to the output path of any store derivations]'
+            '(--force-realise -f)'{--force-realise,-f}'[realise each argument to the query first]'
         )
 
         local subopt
@@ -88,7 +88,7 @@ case "$opt" in
                 --requisites|-R)
                     command_options+=(
                         $common_opts
-                        '--include-outputs[Also include the output paths of store derivations]'
+                        '--include-outputs[also include the output paths of store derivations]'
                     )
                     break
                    ;;
@@ -101,25 +101,25 @@ case "$opt" in
 
         command_options+=(
             + '(query_subcmds)'
-            '--outputs[Print the output paths of the given store derivations]'
-            {--requisites,-R}'[Print the closure of the given store paths]'
-            '--references[Print immediate dependencies of the given store paths]'
-            '--referrers[Print store paths which refer to these paths]'
-            '--referrers-closure[Print the closure under the referrers relation]'
-            '--deriver[Print the deriver of the store paths]'
-            '--graph[Print the references graph of the store paths in Graphviz format]'
-            '--tree[Print the references graph of the store paths as an ASCII tree]'
-            {--binding,-b}'[Print the value of an attribute of the store derivations]:name:'
-            '--hash[Print the SHA-256 hash of the contents of the store paths]'
-            '--size[Print the size in bytes of the contents of the store paths]'
-            '--roots[Print the garbage collector roots that point to the store paths]'
+            '--outputs[print the output paths of the given store derivations]'
+            {--requisites,-R}'[print the closure of the given store paths]'
+            '--references[print immediate dependencies of the given store paths]'
+            '--referrers[print store paths which refer to these paths]'
+            '--referrers-closure[print the closure under the referrers relation]'
+            '--deriver[print the deriver of the store paths]'
+            '--graph[print the references graph of the store paths in Graphviz format]'
+            '--tree[print the references graph of the store paths as an ASCII tree]'
+            {--binding,-b}'[print the value of an attribute of the store derivations]:name:'
+            '--hash[print the SHA-256 hash of the contents of the store paths]'
+            '--size[print the size in bytes of the contents of the store paths]'
+            '--roots[print the garbage collector roots that point to the store paths]'
         )
         break
         ;;
     --verify)
         command_options=(
             $common_opts
-            '--check-contents[Compute and validate the SHA-256 hash of each store item]'
+            '--check-contents[compute and validate the SHA-256 hash of each store item]'
         )
         break
         ;;

--- a/_nixops
+++ b/_nixops
@@ -44,21 +44,21 @@ _1st_arguments=(
 # Options valid for every command
 local -a _nixops_common_arguments
 _nixops_common_arguments=(
-  '(--state -s)'{--state,-s}'[Path to state file that contains the deployments]:Statefile:_files -g \*.nixops'\
+  '(--state -s)'{--state,-s}'[path to state file that contains the deployments]:Statefile:_files -g \*.nixops'\
   '(--deployment -d)'{--deployment,-d}'[UUID or symbolic name of deployment on which to operate]'\
-  '--confirm[Automatically confirm "dangerous" actions]'\
-  '--debug[Turn on debugging output]'\
+  '--confirm[automatically confirm "dangerous" actions]'\
+  '--debug[turn on debugging output]'\
 )
 
 local -a _nixops_include_exclude
 _nixops_include_exclude=(
-  '--include[Only operate on the specified machines]:Machine Names:_hosts' \
-  '--exclude[Do not operate on the specified machines]:Machine Names:_hosts' \
+  '--include[only operate on the specified machines]:Machine Names:_hosts' \
+  '--exclude[do not operate on the specified machines]:Machine Names:_hosts' \
 )
 
 local -a _nixops_search_path_args
 _nixops_search_path_args=(
-  '-I[Add path to the Nix expression search path for all future evaluations]:Path:_nix_complete_includes' \
+  '-I[add path to the Nix expression search path for all future evaluations]:Path:_nix_complete_includes' \
 )
 
 _arguments \
@@ -81,40 +81,40 @@ case "$words[1]" in
     _arguments \
       $_nixops_common_arguments\
       $_nixops_search_path_args \
-      '(--name -n)'{--name,-n}'[Change the symbolic name]:New Name:( )'\
+      '(--name -n)'{--name,-n}'[change the symbolic name]:New Name:( )'\
     ;;
   clone)
     _arguments \
       $_nixops_common_arguments\
-      '(--name -n)'{--name,-n}'[Symbolic name for the new deployment]'\
+      '(--name -n)'{--name,-n}'[symbolic name for the new deployment]'\
     ;;
   delete)
     _arguments \
       $_nixops_common_arguments\
-      '--all[Delete all deployments in the state file]'\
+      '--all[delete all deployments in the state file]'\
       '--force[]'
     ;;
   deploy)
     _arguments \
       $_nixops_common_arguments\
-      '(--kill-obsolete -k)'{--kill-obsolete,-k}'[Destroy machines no longer listed in the deployment specification]'\
+      '(--kill-obsolete -k)'{--kill-obsolete,-k}'[destroy machines no longer listed in the deployment specification]'\
       $__nix_dry_run \
 	  $__nix_repair \
-      '--create-only[Create missing machines only: build nothing and do not touch existing machines]'\
-      '--build-only[Build the configuration without creating or deploying machines]'\
-      '--copy-only[Do everything except activate the new configuration]'\
-      '--check[Check that deployed machines are correctly configured]'\
-      '--allow-reboot[Allow NixOps to reboot the instance if necessary]'\
-      '--force-reboot[Reboot the machine to activate the new configuration]'\
-      '--allow-recreate[Recreate resources that have disappeared]'\
+      '--create-only[create missing machines only: build nothing and do not touch existing machines]'\
+      '--build-only[build the configuration without creating or deploying machines]'\
+      '--copy-only[do everything except activate the new configuration]'\
+      '--check[check that deployed machines are correctly configured]'\
+      '--allow-reboot[allow NixOps to reboot the instance if necessary]'\
+      '--force-reboot[reboot the machine to activate the new configuration]'\
+      '--allow-recreate[recreate resources that have disappeared]'\
       $_nixops_include_exclude \
       $_nixops_search_path_args \
-      '--max-concurrent-copy[Set the maximum concurrent nix-copy-closure processes (Default 5)]:Number:( )'
+      '--max-concurrent-copy[set the maximum concurrent nix-copy-closure processes (Default 5)]:Number:( )'
     ;;
   destroy)
     _arguments \
       $_nixops_common_arguments\
-      '--all[Destroy all deployments]'\
+      '--all[destroy all deployments]'\
       $_nixops_include_exclude \
     ;;
   stop)
@@ -130,14 +130,14 @@ case "$words[1]" in
   info)
     _arguments \
       $_nixops_common_arguments\
-      '--all[Print information about all resources in all known deployments]'\
-      '--plain[Print in a more easily parsed format]'\
-      '--no-eval[Do not evaluate the deployment specification]'
+      '--all[print information about all resources in all known deployments]'\
+      '--plain[print in a more easily parsed format]'\
+      '--no-eval[do not evaluate the deployment specification]'
     ;;
   check)
     _arguments \
       $_nixops_common_arguments\
-      '--all[Check all machines in all known deployments]'
+      '--all[check all machines in all known deployments]'
     ;;
   ssh)
     _arguments \
@@ -147,14 +147,14 @@ case "$words[1]" in
   ssh-for-each)
     _arguments \
       $_nixops_common_arguments\
-      '(--parallel -p)'{--parallel,-p}'[Execute the command on each machine in parallel]'\
+      '(--parallel -p)'{--parallel,-p}'[execute the command on each machine in parallel]'\
       $_nixops_include_exclude \
     ;;
   reboot)
     _arguments \
       $_nixops_common_arguments\
       $_nixops_include_exclude \
-      '--no-wait[Do not wait until the machines have finished rebooting]'
+      '--no-wait[do not wait until the machines have finished rebooting]'
     ;;
   backup)
     _arguments \
@@ -165,22 +165,22 @@ case "$words[1]" in
     _arguments \
       $_nixops_common_arguments\
       $_nixops_include_exclude \
-      '--devices[Restore only the persistent disks which are mapped to the specified device names]:Device names:( )'\
-      '--backup-id[Restore the persistent disks of all machines to a given backup except the ones listed here.]:Backup ids:( )'
+      '--devices[restore only the persistent disks which are mapped to the specified device names]:Device names:( )'\
+      '--backup-id[restore the persistent disks of all machines to a given backup except the ones listed here.]:Backup ids:( )'
     ;;
   show-option)
     _arguments \
       $_nixops_common_arguments\
-      '--xml[Format output as XML]'\
+      '--xml[format output as XML]'\
       '1:machine:_hosts'\
       '2:option:( )'
     ;;
   set-args)
     _arguments \
       $_nixops_common_arguments\
-      '--arg[Set the function argument]:Name:( ):Value:( )'\
-      '--argstr[Like --arg but the value is a string]:Name:( ):Value:( )'\
-      '--unset[Remove a previously set function argument]:Name:( )'
+      '--arg[set the function argument]:Name:( ):Value:( )'\
+      '--argstr[like --arg but the value is a string]:Name:( ):Value:( )'\
+      '--unset[remove a previously set function argument]:Name:( )'
     ;;
   show-console-output)
     _arguments \
@@ -190,7 +190,7 @@ case "$words[1]" in
   export)
     _arguments \
       $_nixops_common_arguments\
-      '--all[Apply to all deployments]'
+      '--all[apply to all deployments]'
     ;;
   import)
     _arguments \

--- a/_nixos-build-vms
+++ b/_nixos-build-vms
@@ -5,7 +5,7 @@ _nix-common-options
 
 _arguments \
   $__nix_common_nixos_build_vms \
-  '--show-trace[Show a trace of the output]'\
-  "--no-out-link[Do not create a 'result' symlink]"\
-  "--help[Show help]"\
+  '--show-trace[show a trace of the output]'\
+  "--no-out-link[do not create a 'result' symlink]"\
+  "--help[show help]"\
   '1:Network Nix Expression:_nix_complete_dotnix_files'

--- a/_nixos-container
+++ b/_nixos-container
@@ -25,7 +25,7 @@ _1st_arguments=(
   )
 
 _arguments \
-  '(- 1 *)--help[Display help]'\
+  '(- 1 *)--help[display help]'\
   '*:: :->subcmds' && return 0
 
 if (( CURRENT==1 )); then
@@ -34,8 +34,8 @@ if (( CURRENT==1 )); then
 fi
 
 local _container_name='1:Container Name:_containers';
-local _container_config='--config[Config]:Config:( )';
-local _container_file='--config-file[Path to the container config file]:Path:_files';
+local _container_config='--config[config]:Config:( )';
+local _container_file='--config-file[path to the container config file]:Path:_files';
 
 case "$words[1]" in
   create)
@@ -43,14 +43,14 @@ case "$words[1]" in
       $_container_name\
       $_container_config\
       $_container_file\
-      '--system-path[System path]:Path:_files'\
-      '--ensure-unique-name[Avoid name conflicts with other containers]'\
-      '--auto-start[Start the container immediately]'\
-      '--nixos-path[Path to <nixpkgs/nixos>]:Path:_files'\
-      '--host-address[Host IP of the veth interface]:host address:'\
+      '--system-path[system path]:Path:_files'\
+      '--ensure-unique-name[avoid name conflicts with other containers]'\
+      '--auto-start[start the container immediately]'\
+      '--nixos-path[path to <nixpkgs/nixos>]:Path:_files'\
+      '--host-address[host IP of the veth interface]:host address:'\
       '--local-address[IPv4 address assined to the interface in the container]:local address:'\
-      '--bridge[Put the host-side of the veth-pair into the named bridge]:Bridge interface'\
-      '--port[Port forwarding]:port forwarding'
+      '--bridge[put the host-side of the veth-pair into the named bridge]:Bridge interface'\
+      '--port[port forwarding]:port forwarding'
     ;;
   run)
     # TODO: There are a few more arguments in this case

--- a/_nixos-generate-config
+++ b/_nixos-generate-config
@@ -4,8 +4,8 @@
 _nix-common-options
 
 _arguments \
-  '--force[Overwrite /etc/nixos/configuration.nix if it exists]:'\
-  '--root[Directory to treat as root of filesystem]:Root directory:_path_files -/'\
-  '--dir[Directory to write configuration files to (Default /etc/nixos)]:Output directory:_path_files -/'\
-  '--no-filesystems[Omit file system information from hardware configuration]'\
-  '--show-hardware-config[Print hardware configuration to stdout without writing anything to disk]'
+  '--force[overwrite /etc/nixos/configuration.nix if it exists]:'\
+  '--root[directory to treat as root of filesystem]:Root directory:_path_files -/'\
+  '--dir[directory to write configuration files to (Default /etc/nixos)]:Output directory:_path_files -/'\
+  '--no-filesystems[omit file system information from hardware configuration]'\
+  '--show-hardware-config[print hardware configuration to stdout without writing anything to disk]'

--- a/_nixos-install
+++ b/_nixos-install
@@ -5,6 +5,6 @@ _nix-common-options
 
 _arguments \
   $__nix_search_path_args \
-  '--root[Treat the given directory as the root of the NixOS installation]:Installation Root:_path_files -/'\
-  '--show-trace[Print a stack trace in case of evaluation errors]'\
-  '--chroot[Chroot into given installation]'
+  '--root[treat the given directory as the root of the NixOS installation]:Installation Root:_path_files -/'\
+  '--show-trace[print a stack trace in case of evaluation errors]'\
+  '--chroot[chroot into given installation]'

--- a/_nixos-option
+++ b/_nixos-option
@@ -19,5 +19,5 @@ _nixos-option-opts() {
 
 _arguments \
     $__nix_search_path_args \
-    '--all[Print the values of all options.]' \
+    '--all[print the values of all options.]' \
     ':NixOS module options:_nixos-option-opts'

--- a/_nixos-rebuild
+++ b/_nixos-rebuild
@@ -17,12 +17,12 @@ _1st_arguments=(
 
 _arguments \
   $__nix_common_nixos_rebuild \
-  '--upgrade[Fetch the latest version of NixOS from the NixOS channel]'\
+  '--upgrade[fetch the latest version of NixOS from the NixOS channel]'\
   '--install-bootloader[(Re)install bootloader on the configured device]'\
-  "--no-build-nix[Don't build Nix package manager]"\
-  '--fast[Equivalent to --no-build-nix --show-trace]'\
-  '--rollback[Roll back to the previous configuration]'\
-  '(--profile-name -p)'{--profile-name,-p}'[Profile to use to track current and previous system configurations]:Profile:_nix_profiles'\
+  "--no-build-nix[don't build Nix package manager]"\
+  '--fast[equivalent to --no-build-nix --show-trace]'\
+  '--rollback[roll back to the previous configuration]'\
+  '(--profile-name -p)'{--profile-name,-p}'[profile to use to track current and previous system configurations]:Profile:_nix_profiles'\
   '1:: :->subcmds' && return 0
 
 case $state in

--- a/_nixos-version
+++ b/_nixos-version
@@ -4,4 +4,4 @@
 _nix-common-options
 
 _arguments \
-  '(- *)'{--hash,--revision}'[Print only the git hash of the channel]'\
+  '(- *)'{--hash,--revision}'[print only the git hash of the channel]'\

--- a/_nixpkgs-review
+++ b/_nixpkgs-review
@@ -8,9 +8,9 @@ _nix-common-options
 
 local -a common_args=(
     '--build-args=[arguments passed to nix when building]:build args:'
-    '--no-shell[Only evaluate and build without executing nix-shell]'
+    '--no-shell[only evaluate and build without executing nix-shell]'
     '(-h --help)'{--help,-h}'[show help]'
-    '--token[github token]:github token:'
+    '--token[GitHub token]:GitHub token:'
 )
 
 local -a common_cmd_args=(
@@ -22,13 +22,13 @@ local -a pr_args=(
     ':pr number to review:'
     '(-c --checkout)'{-c,--checkout}'[merge before building or use exact commit]:merge or commit:(merge commit)'
     "--eval[use ofborg's eval result]::(ofborg local)"
-    "--post-result[Post the nixpkgs-review results as a PR comment]"
+    "--post-result[post the nixpkgs-review results as a PR comment]"
 )
 
 local -a wip_args=(
-    '(-b --branch)'{-b,--branch}'[Branch to compare against with]:branch:__git_ref_specs'
-    '(-s --staged)'{-s,--staged}'[Whether to build staged changes]'
-    '(-r --remote)'{-r,--remote}'[Name of the nixpkgs repo to review]:remote:'
+    '(-b --branch)'{-b,--branch}'[branch to compare against with]:branch:__git_ref_specs'
+    '(-s --staged)'{-s,--staged}'[whether to build staged changes]'
+    '(-r --remote)'{-r,--remote}'[name of the nixpkgs repo to review]:remote:'
 )
 
 if ! which __git_ref_specs > /dev/null; then


### PR DESCRIPTION
Some help strings were starting with a lower case letter while most of
them are starting with an upper case letter. This commit capitalizes
all of them.

Note that official Zsh completions usually prefer to not capitalize
help strings. However, most help strings in nix-zsh-completions are
capitalized, so it seems better to just be consistent.

If you prefer, I can also do a PR with help strings not capitalized.