### PR TITLE
nixos-option: Fix when using flake based setup

### DIFF
--- a/_nixos-option
+++ b/_nixos-option
@@ -6,6 +6,8 @@ _nixos-option-opts() {
     local mods=
     if [[ -n "$NIX_PATH" && "$NIX_PATH" =~ "nixos-config=" ]]; then
         mods="(import <nixos-config>)"
+    else
+        mods="{ nixpkgs.hostPlatform = builtins.currentSystem; }"
     fi
     local options='
       with import <nixpkgs/lib>;


### PR DESCRIPTION
On NixOS 24.05, `nixos-config` is not set in NIX_PATH[1] in flake based setup , then the expr will cause an error:

$ nix-instantiate --eval --expr 'with import <nixpkgs/lib>; (evalModules {modules = import <nixpkgs/nixos/modules/module-list.nix> ++ [ ];}).config'
```
...
error: Neither nixpkgs.hostPlatform nor the legacy option nixpkgs.system has been set.
...
```

Fix it by setting `nixpkgs.hostPlatform = builtins.currentSystem`.

[1]: https://github.com/NixOS/nixpkgs/blob/nixos-24.05/nixos/modules/misc/nixpkgs-flake.nix#L97-L102