### PR TITLE
change clone method to HTTPS

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Oh-My-ZSH Installation
 
 ```zsh
 cd ~/.oh-my-zsh/custom/plugins
-git clone git@github.com:nix-community/nix-zsh-completions.git
+git clone https://github.com/nix-community/nix-zsh-completions.git
 ```
 
 Then add `nix-zsh-completions` to the plugins list in `~/.zshrc`


### PR DESCRIPTION
- ran into issues with requiring a public SSH key on my GitHub account
- switching method to HTTPS was one less headache