### PR TITLE
nixos-generate-config: add missing flags

### DIFF
--- a/_nixos-generate-config
+++ b/_nixos-generate-config
@@ -8,4 +8,6 @@ _arguments \
   '--root[Directory to treat as root of filesystem]:Root directory:_path_files -/'\
   '--dir[Directory to write configuration files to (Default /etc/nixos)]:Output directory:_path_files -/'\
   '--no-filesystems[Omit file system information from hardware configuration]'\
-  '--show-hardware-config[Print hardware configuration to stdout without writing anything to disk]'
+  '--show-hardware-config[Print hardware configuration to stdout without writing anything to disk]'\
+  '--kernel[Choose kernel version (lts or latest)]:kernel version:(lts latest)'\
+  '--flake[Generate flake.nix]'


### PR DESCRIPTION
Add completion for --flake and --kernel options  